### PR TITLE
Stringify objects with keys not being valid identifiers

### DIFF
--- a/node-stringify.js
+++ b/node-stringify.js
@@ -34,7 +34,7 @@ function stringify(obj) {
 
   if (_.isObject(obj))
     return '({' + _.map(obj, function (v, k) {
-      return k + ':' + stringify(v)
+      return stringify(k) + ':' + stringify(v)
     }).join(',') + '})'
 }
 

--- a/spec/node-stringify.spec.js
+++ b/spec/node-stringify.spec.js
@@ -109,4 +109,8 @@ describe('node-stringify test', function () {
   it('should stringify an object containning arrays', function () {
     testEval({a: [1, 2, 3], b: /foo$/i})
   })
+
+  it('should stringify an object having non-valid identifiers as keys', function () {
+    testEval({"a'bc": [1]})
+  })
 })


### PR DESCRIPTION
Trying to serialize dictionary from [hunspell-spellchecker](https://github.com/GitbookIO/hunspell-spellchecker) it was discovered that this module fails to serialize an object properly if its keys have characters that make it invalid identifier, such as single quote. This PR fixes it.